### PR TITLE
Made logging more consistent

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,12 @@ var rootCmd = &cobra.Command{
 			log.SetFormatter(&log.TextFormatter{
 				FullTimestamp: true,
 			})
+		} else {
+			log.SetFormatter(&log.TextFormatter{
+				FullTimestamp: false,
+				DisableColors: true,
+				DisableTimestamp: true,
+			})
 		}
 	},
 

--- a/protocol/raw.go
+++ b/protocol/raw.go
@@ -142,7 +142,7 @@ func ValidateAndDecodeMessage(message []byte) ([]byte, byte, []byte) {
 		xor ^= 1
 		msg = XorMessageWith(message, xor)
 		if !ValidateChecksum(msg) {
-			fmt.Printf("Bad sum for (%s)\n", hex.EncodeToString(message))
+			log.Debugf("Bad sum for (%s)\n", hex.EncodeToString(message))
 			return nil, 0, nil
 		}
 	}


### PR DESCRIPTION
1. Moved logging of bad checksums to log.Debug
2. Removed timestamps printing by default to make the logs more compact. This is used with systemd logging, that already ahs the timestamps