### PR TITLE
Made logging more consistent

### DIFF
--- a/protocol/raw.go
+++ b/protocol/raw.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"encoding/hex"
-	"fmt"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -133,7 +132,7 @@ func ValidateChecksum(message []byte) bool {
 // plus any trailing data.
 func ValidateAndDecodeMessage(message []byte) ([]byte, byte, []byte) {
 	if len(message) < 4 {
-		fmt.Printf("Short msg\n")
+		log.Debugf("Short msg\n")
 		return nil, 0, nil
 	}
 	xor := message[2]


### PR DESCRIPTION
1. Moved logging of bad checksums to log.Debug
2. Removed timestamps printing by default to make the logs more compact. This is used with systemd logging, that already ahs the timestamps