### PR TITLE
Fixed YAML configuration file parsing. Now it works

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // clientCmd represents the client command
@@ -43,6 +44,7 @@ func init() {
 	// clientCmd.PersistentFlags().String("foo", "", "A help for foo")
 	clientCmd.PersistentFlags().String("address", "192.168.8.46:8080", "Address to connect to")
 
+	viper.BindPFlag("address", clientCmd.Flags().Lookup("address"))
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// clientCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")


### PR DESCRIPTION
YAML file format example:

mqtt_server: "tcp://localhost:1883"
mqtt_username: "XXXXX"
mqtt_password: "XXXXX"
update_interval: 10m
wifi_restart_time: 30s
wifi_restart_retry_time: 2m